### PR TITLE
Abort build script on errors.

### DIFF
--- a/build_src.sh
+++ b/build_src.sh
@@ -74,6 +74,9 @@ case $var in
 esac
 done
 
+set -e
+set -x
+
 # Check release and version weren't both set
 if [ "$RELEASE" == "yes" ] && [ -n "$GIVEN_VERSION" ]; then
  echo "Cannot set release and version options at the same time."


### PR DESCRIPTION
- Added set -e to abort the build script when there have been errors with eg a wrong spatch or a missing spatch.
- Added set -x to see which commands are executed.

Added these two after parsing command-line options to have a nice --help output.