### PR TITLE
gve: Upgrade memory barrier in poll routine

### DIFF
--- a/google/gve/gve_main.c
+++ b/google/gve/gve_main.c
@@ -177,10 +177,9 @@ static int gve_napi_poll(struct napi_struct *napi, int budget)
 		iowrite32be(GVE_IRQ_ACK | GVE_IRQ_EVENT, irq_doorbell);
 
 		/* Double check we have no extra work.
-		 * * Ensure unmask synchronizes with checking for work.
-		 * */
-		dma_rmb();
-
+		 * Ensure unmask synchronizes with checking for work.
+		 */
+		smp_mb();
 		if (block->tx) reschedule |= gve_tx_poll(block, -1);
 		if (block->rx) reschedule |= gve_rx_work_pending(block->rx);
 

--- a/google/gve/gve_rx.c
+++ b/google/gve/gve_rx.c
@@ -545,8 +545,6 @@ bool gve_rx_work_pending(struct gve_rx_ring *rx)
 	next_idx = rx->cnt & rx->mask;
 	desc = rx->desc.desc_ring + next_idx;
 
-	/* make sure we have synchronized the seq no with the device */
-	smp_mb();
 	flags_seq = desc->flags_seq;
 
 	return (GVE_SEQNO(flags_seq) == rx->desc.seqno);


### PR DESCRIPTION
We need a hard memory barrier in the poll routine for
both tx and rx, so upgrade the barrier in the poll routine
and remove the rx specific barrier since it is now the same.

Signed-off-by: Catherine Sullivan <csully@google.com>