### PR TITLE
Coccinelle fixes

### DIFF
--- a/patches/ethtool_link_ksettings.cocci
+++ b/patches/ethtool_link_ksettings.cocci
@@ -1,0 +1,22 @@
+@ remove_field @
+identifier gve_ops, get_link_ksettings_func;
+@@
+
+const struct ethtool_ops gve_ops = {
+	.set_priv_flags = gve_set_priv_flags,
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,6,0)
+	.get_link_ksettings = get_link_ksettings_func
++#endif /* LINUX_VERSION_CODE >= KERNEL_VERSION(4,6,0) */
+};
+
+
+@ function depends on remove_field @
+identifier remove_field.get_link_ksettings_func, net_device, ethtool_link_ksettings, netdev, cmd;
+@@
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,6,0)
+static int get_link_ksettings_func(struct net_device *netdev,
+				       struct ethtool_link_ksettings *cmd)
+{
+...
+}
++#endif /* LINUX_VERSION_CODE >= KERNEL_VERSION(4,6,0) */

--- a/patches/include-version.cocci
+++ b/patches/include-version.cocci
@@ -3,4 +3,4 @@
 
 +#include "gve_linux_version.h"
 
-#include ...
+#include "..."

--- a/patches/napi_alloc_skb.cocci
+++ b/patches/napi_alloc_skb.cocci
@@ -1,12 +1,10 @@
 @ fix_napi_skb_alloc exists @
-identifier netdev, napi, skb, len;
+identifier napi, skb, len, sk_buff;
 @@
-struct net_device *netdev = ...;
-...
--skb = napi_alloc_skb(napi, len);
-+#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,19,0)
-+skb = napi_alloc_skb(napi, len);
-+#else /* LINUX_VERSION_CODE >= KERNEL_VERSION(3,19,0) */
-+skb = netdev_alloc_skb_ip_align(netdev, len);
-+#endif /* LINUX_VERSION_CODE >= KERNEL_VERSION(3,19,0) */
 
+...
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,19,0)
+struct sk_buff *skb = napi_alloc_skb(napi, len);
++#else /* LINUX_VERSION_CODE >= KERNEL_VERSION(3,19,0) */
++struct sk_buff *skb = netdev_alloc_skb_ip_align(netdev, len);
++#endif /* LINUX_VERSION_CODE >= KERNEL_VERSION(3,19,0) || RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(7, 3) */

--- a/patches/page_ref.cocci
+++ b/patches/page_ref.cocci
@@ -1,0 +1,21 @@
+@ fix_page_ref_add exists @
+expression p, v;
+@@
+...
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,6,0)
+page_ref_add(p, v);
++#else /* LINUX_VERSION_CODE >= KERNEL_VERSION(4,6,0) */
++atomic_add(v, &p->_count);
++#endif /* LINUX_VERSION_CODE >= KERNEL_VERSION(4,6,0) */
+...
+
+@ fix_page_ref_sub exists @
+expression p, v;
+@@
+...
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,6,0)
+page_ref_sub(p, v);
++#else /* LINUX_VERSION_CODE >= KERNEL_VERSION(4,6,0) */
++atomic_sub(v, &p->_count);
++#endif /* LINUX_VERSION_CODE >= KERNEL_VERSION(4,6,0) */
+...


### PR DESCRIPTION
These patches modify/add coccinelle patches which fix compilation problems on Linux 4.4 and compatibility problems with coccinelle-1.0.4.