### PR TITLE
coccinelle: Fix napi_alloc_skb patch.

### DIFF
--- a/patches/napi_alloc_skb.cocci
+++ b/patches/napi_alloc_skb.cocci
@@ -1,10 +1,14 @@
 @ fix_napi_skb_alloc exists @
-identifier napi, skb, len, sk_buff;
+identifier netdev, napi_ptr, skb, len;
+identifier func;
 @@
-
+func(struct net_device *netdev, struct napi_struct *napi_ptr, ...)
+{
 ...
 +#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,19,0)
-struct sk_buff *skb = napi_alloc_skb(napi, len);
+struct sk_buff *skb = napi_alloc_skb(napi_ptr, len);
 +#else /* LINUX_VERSION_CODE >= KERNEL_VERSION(3,19,0) */
 +struct sk_buff *skb = netdev_alloc_skb_ip_align(netdev, len);
-+#endif /* LINUX_VERSION_CODE >= KERNEL_VERSION(3,19,0) || RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(7, 3) */
++#endif /* LINUX_VERSION_CODE >= KERNEL_VERSION(3,19,0) */
+...
+}


### PR DESCRIPTION
Patch 2eb19b94a75d introduced an undefined variable error for kernels <
3.19.
This patch corrects the error so that the "struct net_device* dev"
parameter is correctly referred to by netdev_alloc_skb_ip_align.

Signed-off-by: David Awogbemila <awogbemila@google.com>