### PR TITLE
Bugfixes

### DIFF
--- a/google/gve/gve_main.c
+++ b/google/gve/gve_main.c
@@ -179,7 +179,7 @@ static int gve_napi_poll(struct napi_struct *napi, int budget)
 		/* Double check we have no extra work.
 		 * Ensure unmask synchronizes with checking for work.
 		 */
-		smp_mb();
+		mb();
 		if (block->tx) reschedule |= gve_tx_poll(block, -1);
 		if (block->rx) reschedule |= gve_rx_work_pending(block->rx);
 

--- a/google/gve/gve_main.c
+++ b/google/gve/gve_main.c
@@ -312,14 +312,17 @@ static void gve_free_notify_blocks(struct gve_priv *priv)
 {
 	int i;
 
-	/* Free the irqs */
-	for (i = 0; i < priv->num_ntfy_blks; i++) {
-		struct gve_notify_block *block = &priv->ntfy_blocks[i];
-		int msix_idx = i;
-
-		irq_set_affinity_hint(priv->msix_vectors[msix_idx].vector,
-				      NULL);
-		free_irq(priv->msix_vectors[msix_idx].vector, block);
+	if (priv->msix_vectors) {
+		/* Free the irqs */
+		for (i = 0; i < priv->num_ntfy_blks; i++) {
+			struct gve_notify_block *block = &priv->ntfy_blocks[i];
+			int msix_idx = i;
+	
+			irq_set_affinity_hint(priv->msix_vectors[msix_idx].vector,
+					      NULL);
+			free_irq(priv->msix_vectors[msix_idx].vector, block);
+		}
+		free_irq(priv->msix_vectors[priv->mgmt_msix_idx].vector, priv);
 	}
 	kvfree(priv->ntfy_blocks);
 	priv->ntfy_blocks = NULL;
@@ -327,7 +330,6 @@ static void gve_free_notify_blocks(struct gve_priv *priv)
 			  sizeof(*priv->irq_db_indices),
 			  priv->irq_db_indices, priv->irq_db_indices_bus);
 	priv->irq_db_indices = NULL;
-	free_irq(priv->msix_vectors[priv->mgmt_msix_idx].vector, priv);
 	pci_disable_msix(priv->pdev);
 	kfree(priv->msix_vectors);
 	priv->msix_vectors = NULL;

--- a/google/gve/gve_main.c
+++ b/google/gve/gve_main.c
@@ -218,6 +218,7 @@ static int gve_alloc_notify_blocks(struct gve_priv *priv)
 		int vecs_left = new_num_ntfy_blks % 2;
 
 		priv->num_ntfy_blks = new_num_ntfy_blks;
+		priv->mgmt_msix_idx = priv->num_ntfy_blks;
 		priv->tx_cfg.max_queues = min_t(int, priv->tx_cfg.max_queues,
 						vecs_per_type);
 		priv->rx_cfg.max_queues = min_t(int, priv->rx_cfg.max_queues,

--- a/google/gve/gve_rx.c
+++ b/google/gve/gve_rx.c
@@ -545,6 +545,8 @@ bool gve_rx_work_pending(struct gve_rx_ring *rx)
 	next_idx = rx->cnt & rx->mask;
 	desc = rx->desc.desc_ring + next_idx;
 
+	/* make sure we have synchronized the seq no with the device */
+	smp_mb();
 	flags_seq = desc->flags_seq;
 
 	return (GVE_SEQNO(flags_seq) == rx->desc.seqno);

--- a/google/gve/gve_tx.c
+++ b/google/gve/gve_tx.c
@@ -216,10 +216,11 @@ static int gve_tx_alloc_ring(struct gve_priv *priv, int idx)
 	tx->dev = &priv->pdev->dev;
 	if (!tx->raw_addressing) {
 		tx->tx_fifo.qpl = gve_assign_tx_qpl(priv);
-
+		if (!tx->tx_fifo.qpl)
+			goto abort_with_desc;
 		/* map Tx FIFO */
 		if (gve_tx_fifo_init(priv, &tx->tx_fifo))
-			goto abort_with_desc;
+			goto abort_with_qpl;
 	}
 
 	tx->q_resources =
@@ -240,6 +241,9 @@ static int gve_tx_alloc_ring(struct gve_priv *priv, int idx)
 abort_with_fifo:
 	if (!tx->raw_addressing)
 		gve_tx_fifo_release(priv, &tx->tx_fifo);
+abort_with_qpl:
+	if (!tx->raw_addressing)
+		gve_unassign_qpl(priv, tx->tx_fifo.qpl->id);
 abort_with_desc:
 	dma_free_coherent(hdev, bytes, tx->desc, tx->bus);
 	tx->desc = NULL;


### PR DESCRIPTION
This pull request includes the following bug fixes:

- gve: Check TX QPL was actually assigned 
- gve: Update mgmt_msix_idx if num_ntfy changes
- gve: Add NULL pointer checks when freeing irqs. 
- gve: Upgrade and re-apply memory barriers

A bit of context around "gve: Upgrade and re-apply memory barriers" is that we would want to keep this tree as close as possible to the in-tree Linux driver, so a memory barrier that was removed from gve_rx_work_pending in an earlier fix is reapplied.