### PR TITLE
gve: replace kfree() with kvfree()

### DIFF
--- a/google/gve/gve_main.c
+++ b/google/gve/gve_main.c
@@ -302,7 +302,7 @@ abort_with_mgmt_vector:
 abort_with_msix_enabled:
 	pci_disable_msix(priv->pdev);
 abort_with_msix_vectors:
-	kfree(priv->msix_vectors);
+	kvfree(priv->msix_vectors);
 	priv->msix_vectors = NULL;
 	return err;
 }
@@ -328,7 +328,7 @@ static void gve_free_notify_blocks(struct gve_priv *priv)
 	priv->irq_db_indices = NULL;
 	free_irq(priv->msix_vectors[priv->mgmt_msix_idx].vector, priv);
 	pci_disable_msix(priv->pdev);
-	kfree(priv->msix_vectors);
+	kvfree(priv->msix_vectors);
 	priv->msix_vectors = NULL;
 }
 
@@ -539,12 +539,12 @@ static int gve_alloc_rings(struct gve_priv *priv)
 	return 0;
 
 free_rx:
-	kfree(priv->rx);
+	kvfree(priv->rx);
 	priv->rx = NULL;
 free_tx_queue:
 	gve_tx_free_rings(priv);
 free_tx:
-	kfree(priv->tx);
+	kvfree(priv->tx);
 	priv->tx = NULL;
 	return err;
 }
@@ -583,7 +583,7 @@ static void gve_free_rings(struct gve_priv *priv)
 			gve_remove_napi(priv, ntfy_idx);
 		}
 		gve_tx_free_rings(priv);
-		kfree(priv->tx);
+		kvfree(priv->tx);
 		priv->tx = NULL;
 	}
 	if (priv->rx) {
@@ -592,7 +592,7 @@ static void gve_free_rings(struct gve_priv *priv)
 			gve_remove_napi(priv, ntfy_idx);
 		}
 		gve_rx_free_rings(priv);
-		kfree(priv->rx);
+		kvfree(priv->rx);
 		priv->rx = NULL;
 	}
 }
@@ -685,9 +685,9 @@ static void gve_free_queue_page_list(struct gve_priv *priv, u32 id)
 		gve_free_page(&priv->pdev->dev, qpl->pages[i],
 			      qpl->page_buses[i], gve_qpl_dma_dir(priv, id));
 
-	kfree(qpl->page_buses);
+	kvfree(qpl->page_buses);
 free_pages:
-	kfree(qpl->pages);
+	kvfree(qpl->pages);
 	priv->num_registered_pages -= qpl->num_entries;
 
 }
@@ -731,7 +731,7 @@ static int gve_alloc_qpls(struct gve_priv *priv)
 free_qpls:
 	for (j = 0; j <= i; j++)
 		gve_free_queue_page_list(priv, j);
-	kfree(priv->qpls);
+	kvfree(priv->qpls);
 	return err;
 }
 
@@ -744,12 +744,12 @@ static void gve_free_qpls(struct gve_priv *priv)
 	if (priv->raw_addressing)
 		return;
 
-	kfree(priv->qpl_cfg.qpl_id_map);
+	kvfree(priv->qpl_cfg.qpl_id_map);
 
 	for (i = 0; i < num_qpls; i++)
 		gve_free_queue_page_list(priv, i);
 
-	kfree(priv->qpls);
+	kvfree(priv->qpls);
 }
 
 /* Use this to schedule a reset when the device is capable of continuing


### PR DESCRIPTION
Variables allocated by kvzalloc() should not be freed by kfree().
Because they may be allocated by vmalloc().
So we replace kfree with kvfree() here.