### PR TITLE
Update installation instructions to not suggest "skip build"

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,6 @@ will be accepted upstream at all.
 
 ## GitHub
 
-If you downloaded a release tarball from GitHub: This source code should
-already be multi-kernel compatible. You can skip down to Compiling the Driver.
-
 ### Building the multi-kernel compatible driver source
 
 If you downloaded the source from GitHub: To install this driver on anything


### PR DESCRIPTION
Current instructions don't work as is because since release 1.3.2 we have not been uploading the built source directory.  And even if we start uploading the directory, the compilation command will not  work as is because one would need to change the make parameter M to the point to the directory where one unpacked the tar.

Hence deleting the section as building source takes fewer than couple of minutes and alternative is still confusing.

Signed-off-by: Ankit Garg <nktgrg@google.com>
