### PR TITLE
fix(gve): use gve_schedule_reset on adminq flow rule timeout

### DIFF
--- a/google/gve/gve_adminq.c
+++ b/google/gve/gve_adminq.c
@@ -1322,7 +1322,7 @@ gve_adminq_configure_flow_rule(struct gve_priv *priv,
 
 	if (err == -ETIME) {
 		dev_err(&priv->pdev->dev, "Timeout to configure the flow rule, trigger reset");
-		gve_reset(priv, true);
+		gve_schedule_reset(priv);
 	} else if (!err) {
 		priv->flow_rules_cache.rules_cache_synced = false;
 	}


### PR DESCRIPTION
### Summary
Fixes a hard deadlock (AB-BA circular lock inversion) during early boot or driver reset on EL10 / RHEL 10 kernels when AdminQ flow rule configuration times out.

### Root Cause
Calling `gve_reset()` synchronously inside `gve_adminq_configure_flow_rule()` when an AdminQ command times out violates the driver's lock hierarchy. When invoked under netlink / ethtool callbacks, this creates a lock inversion deadlock with `rtnl_lock`.

### Fix
Replaces direct `gve_reset()` with `gve_schedule_reset()` to defer reset execution safely to `gve_service_task` under the proper lock context.

Fixes #93

CC: @hramamurthy12 @josh8551021 @jordanrh1 @agarg2008

Co-developed-by: Gemini AI <renich+gemini@woralelandia.com>
Signed-off-by: Rénich Bon Ćirić <renich@woralelandia.com>