### PR TITLE
gve: fix AF_XDP pool teardown ordering

### DIFF
--- a/build/gve_main.c
+++ b/build/gve_main.c
@@ -2005,36 +2005,64 @@ static int gve_xsk_pool_disable(struct net_device *dev,
 	if (qid >= priv->rx_cfg.num_queues)
 		return -EINVAL;
 
+	pool = xsk_get_pool_from_qid(dev, qid);
 	clear_bit(qid, priv->xsk_pools);
 
-	pool = xsk_get_pool_from_qid(dev, qid);
+	if (!netif_running(dev) || !priv->tx_cfg.num_xdp_queues) {
+		if (pool)
+			xsk_pool_dma_unmap(pool,
+					   DMA_ATTR_SKIP_CPU_SYNC |
+					   DMA_ATTR_WEAK_ORDERING);
+		return 0;
+	}
+
+	/* Stop and start RDA queues to repost buffers. */
+	if (!gve_is_qpl(priv) && priv->xdp_prog) {
+		err = gve_configure_rings_xdp(priv, priv->rx_cfg.num_queues);
+		if (err) {
+			set_bit(qid, priv->xsk_pools);
+			return err;
+		}
+
+		if (pool)
+			xsk_pool_dma_unmap(pool,
+					   DMA_ATTR_SKIP_CPU_SYNC |
+					   DMA_ATTR_WEAK_ORDERING);
+		return 0;
+	}
+
+	napi_rx = &priv->ntfy_blocks[priv->rx[qid].ntfy_id].napi;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,14,0) || RHEL_VERSION_GTE(10,2)
+	napi_disable_locked(napi_rx); /* make sure current rx poll is done */
+#else /* LINUX_VERSION_CODE >= KERNEL_VERSION(6,14,0) || RHEL_VERSION_GTE(10,2) */
+	napi_disable(napi_rx); /* make sure current rx poll is done */
+#endif /* LINUX_VERSION_CODE >= KERNEL_VERSION(6,14,0) || RHEL_VERSION_GTE(10,2) */
+
+	tx_qid = gve_xdp_tx_queue_id(priv, qid);
+	napi_tx = &priv->ntfy_blocks[priv->tx[tx_qid].ntfy_id].napi;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,14,0) || RHEL_VERSION_GTE(10,2)
+	napi_disable_locked(napi_tx); /* make sure current tx poll is done */
+#else /* LINUX_VERSION_CODE >= KERNEL_VERSION(6,14,0) || RHEL_VERSION_GTE(10,2) */
+	napi_disable(napi_tx); /* make sure current tx poll is done */
+#endif /* LINUX_VERSION_CODE >= KERNEL_VERSION(6,14,0) || RHEL_VERSION_GTE(10,2) */
+
+	gve_unreg_xsk_pool(priv, qid);
+	smp_mb(); /* Make sure it is visible to the workers on datapath */
 	if (pool)
 		xsk_pool_dma_unmap(pool,
 				   DMA_ATTR_SKIP_CPU_SYNC |
 				   DMA_ATTR_WEAK_ORDERING);
 
-	if (!netif_running(dev) || !priv->tx_cfg.num_xdp_queues)
-		return 0;
-
-	/* Stop and start RDA queues to repost buffers. */
-	if (!gve_is_qpl(priv) && priv->xdp_prog) {
-		err = gve_configure_rings_xdp(priv, priv->rx_cfg.num_queues);
-		if (err)
-			return err;
-	}
-
-	napi_rx = &priv->ntfy_blocks[priv->rx[qid].ntfy_id].napi;
-	napi_disable(napi_rx); /* make sure current rx poll is done */
-
-	tx_qid = gve_xdp_tx_queue_id(priv, qid);
-	napi_tx = &priv->ntfy_blocks[priv->tx[tx_qid].ntfy_id].napi;
-	napi_disable(napi_tx); /* make sure current tx poll is done */
-
-	gve_unreg_xsk_pool(priv, qid);
-	smp_mb(); /* Make sure it is visible to the workers on datapath */
-
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,14,0) || RHEL_VERSION_GTE(10,2)
+	napi_enable_locked(napi_rx);
+#else /* LINUX_VERSION_CODE >= KERNEL_VERSION(6,14,0) || RHEL_VERSION_GTE(10,2) */
 	napi_enable(napi_rx);
+#endif /* LINUX_VERSION_CODE >= KERNEL_VERSION(6,14,0) || RHEL_VERSION_GTE(10,2) */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,14,0) || RHEL_VERSION_GTE(10,2)
+	napi_enable_locked(napi_tx);
+#else /* LINUX_VERSION_CODE >= KERNEL_VERSION(6,14,0) || RHEL_VERSION_GTE(10,2) */
 	napi_enable(napi_tx);
+#endif /* LINUX_VERSION_CODE >= KERNEL_VERSION(6,14,0) || RHEL_VERSION_GTE(10,2) */
 	if (gve_is_gqi(priv)) {
 		if (gve_rx_work_pending(&priv->rx[qid]))
 			napi_schedule(napi_rx);

--- a/google/gve/gve_main.c
+++ b/google/gve/gve_main.c
@@ -1689,36 +1689,48 @@ static int gve_xsk_pool_disable(struct net_device *dev,
 	if (qid >= priv->rx_cfg.num_queues)
 		return -EINVAL;
 
+	pool = xsk_get_pool_from_qid(dev, qid);
 	clear_bit(qid, priv->xsk_pools);
 
-	pool = xsk_get_pool_from_qid(dev, qid);
+	if (!netif_running(dev) || !priv->tx_cfg.num_xdp_queues) {
+		if (pool)
+			xsk_pool_dma_unmap(pool,
+					   DMA_ATTR_SKIP_CPU_SYNC |
+					   DMA_ATTR_WEAK_ORDERING);
+		return 0;
+	}
+
+	/* Stop and start RDA queues to repost buffers. */
+	if (!gve_is_qpl(priv) && priv->xdp_prog) {
+		err = gve_configure_rings_xdp(priv, priv->rx_cfg.num_queues);
+		if (err) {
+			set_bit(qid, priv->xsk_pools);
+			return err;
+		}
+
+		if (pool)
+			xsk_pool_dma_unmap(pool,
+					   DMA_ATTR_SKIP_CPU_SYNC |
+					   DMA_ATTR_WEAK_ORDERING);
+		return 0;
+	}
+
+	napi_rx = &priv->ntfy_blocks[priv->rx[qid].ntfy_id].napi;
+	napi_disable_locked(napi_rx); /* make sure current rx poll is done */
+
+	tx_qid = gve_xdp_tx_queue_id(priv, qid);
+	napi_tx = &priv->ntfy_blocks[priv->tx[tx_qid].ntfy_id].napi;
+	napi_disable_locked(napi_tx); /* make sure current tx poll is done */
+
+	gve_unreg_xsk_pool(priv, qid);
+	smp_mb(); /* Make sure it is visible to the workers on datapath */
 	if (pool)
 		xsk_pool_dma_unmap(pool,
 				   DMA_ATTR_SKIP_CPU_SYNC |
 				   DMA_ATTR_WEAK_ORDERING);
 
-	if (!netif_running(dev) || !priv->tx_cfg.num_xdp_queues)
-		return 0;
-
-	/* Stop and start RDA queues to repost buffers. */
-	if (!gve_is_qpl(priv) && priv->xdp_prog) {
-		err = gve_configure_rings_xdp(priv, priv->rx_cfg.num_queues);
-		if (err)
-			return err;
-	}
-
-	napi_rx = &priv->ntfy_blocks[priv->rx[qid].ntfy_id].napi;
-	napi_disable(napi_rx); /* make sure current rx poll is done */
-
-	tx_qid = gve_xdp_tx_queue_id(priv, qid);
-	napi_tx = &priv->ntfy_blocks[priv->tx[tx_qid].ntfy_id].napi;
-	napi_disable(napi_tx); /* make sure current tx poll is done */
-
-	gve_unreg_xsk_pool(priv, qid);
-	smp_mb(); /* Make sure it is visible to the workers on datapath */
-
-	napi_enable(napi_rx);
-	napi_enable(napi_tx);
+	napi_enable_locked(napi_rx);
+	napi_enable_locked(napi_tx);
 	if (gve_is_gqi(priv)) {
 		if (gve_rx_work_pending(&priv->rx[qid]))
 			napi_schedule(napi_rx);


### PR DESCRIPTION
## Summary

Fix two ordering problems while disabling an AF_XDP zero-copy pool:

* keep the UMEM DMA mapping valid until the datapath that can still use it has been quiesced;
* return after DQO ring reconfiguration, which has already stopped the old queues, unregistered their XDP/XSK state, and started replacement queues;
* use the NAPI helpers for callers that already hold the netdev operation lock in the remaining GQI path.

## Root cause

`gve_xsk_pool_disable()` currently calls `xsk_pool_dma_unmap()` before stopping DQO RX. An in-flight `gve_rx_xsk_dqo()` can consequently reach `xsk_buff_dma_sync_for_cpu()` after the pool's DMA device has been cleared. In the observed fault, this produced a NULL-device access at `0x31c`:

```text
BUG: kernel NULL pointer dereference, address: 000000000000031c
RIP: gve_rx_xsk_dqo+0x55/0x440 [gve]
RDI: 0000000000000000
CR2: 000000000000031c
```

On DQO, `gve_configure_rings_xdp()` already tears down the old queues and creates replacements without the pool after its bitmap bit is cleared. Falling through afterward operates on the replacement rings. On kernels where XSK pool setup is serialized by the netdev operation lock, the subsequent plain `napi_disable()` can also self-deadlock:

```text
Workqueue: events xp_release_deferred
napi_disable+0x1d/0x50
gve_xsk_pool_disable+0xed/0x1d0 [gve]
gve_xdp+0x14a/0x1c0 [gve]
xp_disable_drv_zc+0x89/0xe0
xp_clear_dev+0x59/0xf0
xp_release_deferred+0x20/0x90
```

## Reproducer

The failure was reproduced on two Compute Engine `c4n-highcpu-16` VMs using the DQO RDA queue format and Ubuntu 26.04 kernel `7.0.0-1008-gcp`. The in-tree driver reports version `1.0.0`; the affected teardown sequence is also present in official GVE v1.4.11.

Configure the gVNIC for native XDP, repeatedly bind AF_XDP zero-copy sockets to all queues, send traffic, then close the sockets and detach XDP:

```bash
sudo ethtool -K ens3 rx-gro-hw off
sudo ethtool -G ens3 rx-buf-len 2048 tcp-data-split off
sudo ethtool -L ens3 rx 8 tx 8
```

The baseline produced either the `gve_rx_xsk_dqo()` NULL dereference above or tasks stuck in `gve_xsk_pool_disable()` during socket release.

## Validation

The patched v1.4.11 module was built against the exact `7.0.0-1008-gcp` headers and loaded on both VMs. Module SHA-256:

```text
881afb1de651d165f6b15dbf9a0098ee6f4e15bda02b3cf2311dd28cb186d9db
```

Results:

* two paired 1-queue native zero-copy attach/traffic/detach cycles, including unlimited-rate traffic;
* 16 paired 8-queue cycles, including a reboot from the persistently installed module;
* three warm-ups and nine measured 60-second runs across 64-byte, 1000-byte, and IMIX traffic;
* no recovery resets, NULL dereferences, hung tasks, NAPI warnings, or GVE resets in either serial console after the patch;
* the generated multi-kernel source also builds against a 5.14 kernel, exercising the compatibility branch for the older NAPI helper names.

The patch is intentionally limited to XSK pool teardown and does not add device-specific behavior to the AF_XDP application.
